### PR TITLE
[DOC] Adding user-guide docs for CI testing and constraint-based discovery

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -11,7 +11,7 @@ generated/
 auto_examples
 
 # dev tools
-
+.vscode
 .envrc
 .python-version
 .idea

--- a/doc/_templates/docs-navbar.html
+++ b/doc/_templates/docs-navbar.html
@@ -10,7 +10,7 @@
         </button>
         <ul class="dropdown-menu" aria-labelledby="dLabelMore">
             {%- for ver, txt in versions_dropdown.items() %}
-            <li><a href="https://pywhy.github.io/dodiscover/{{ ver }}/index.html">{{ txt }}</a></li>
+            <li><a href="https://www.pywhy.org/dodiscover/{{ ver }}/index.html">{{ txt }}</a></li>
             {%- endfor %}
         </ul>
     </li>

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block extrahead %}
-    <link rel="canonical" href="https://pywhy.github.io/dodiscover/stable/index.html" />
+    <link rel="canonical" href="https://www.pywhy.org/dodiscover/stable/index.html" />
     <script type="text/javascript" src="{{ pathto('_static/copybutton.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/scrollfix.js', 1) }}"></script>
 {{ super() }}

--- a/doc/_templates/version-switcher.html
+++ b/doc/_templates/version-switcher.html
@@ -5,7 +5,7 @@
     </button>
     <div class="dropdown-menu list-group-flush py-0" aria-labelledby="dLabelMore">
         {%- for ver, txt in versions_dropdown.items() %}
-        <a class="list-group-item list-group-item-action py-1" href="https://pywhy.github.io/dodiscover/{{ ver }}/index.html">{{ txt }}</a>
+        <a class="list-group-item list-group-item-action py-1" href="https://www.pywhy.org/dodiscover/{{ ver }}/index.html">{{ txt }}</a>
         {%- endfor %}
     </div>
 </div>

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -51,7 +51,6 @@ Constraint-based structure learning
    ConditioningSetSelection
    PC
    FCI
-   PsiFCI
 
 Comparing causal discovery algorithms
 =====================================

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -34,7 +34,6 @@ See docs for ``Context`` and ``make_context`` for more information.
 
    make_context
    ContextBuilder
-   InterventionalContextBuilder
    context.Context
 
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,3 +1,5 @@
+.. _api_ref:
+
 ###
 API
 ###
@@ -32,6 +34,7 @@ See docs for ``Context`` and ``make_context`` for more information.
 
    make_context
    ContextBuilder
+   InterventionalContextBuilder
    context.Context
 
 
@@ -44,9 +47,11 @@ Constraint-based structure learning
 
    LearnSkeleton
    LearnSemiMarkovianSkeleton
-   SkeletonMethods
+   LearnInterventionSkeleton
+   ConditioningSetSelection
    PC
    FCI
+   PsiFCI
 
 Comparing causal discovery algorithms
 =====================================

--- a/doc/conditional_independence.rst
+++ b/doc/conditional_independence.rst
@@ -1,32 +1,40 @@
 .. _conditional_independence:
 
-========================
-Conditional Independence
-========================
+============
+Independence
+============
 
 .. currentmodule:: dodiscover.ci
 
-Testing for invariances in the data, such as conditional independence (CI) can be represented graphically
-in the form of d-separation statements under the causal faithfulness assumption. Given this, one
-is interested in high-powered and well-controlled CI tests that can be used to test for CI in data.
+Probabilistic independence among two random variables is when the realization of one
+variable does not affect the distribution of the other variable. It is a fundamental notion
+in probability and statistics that is used to determine if information about some variables
+can be gleaned from observations of other variables. Independence can be tested statistically
+in the form of unconditional (or marginal) independence, or conditional independence (CI).
+In the following, we present a brief overview of the various approaches to CI testing, where
+the marginal case is a special case when the conditioning set is empty.
 
-CI tests are framed as a statistical hypothesis test, with the following null hypothesis for a given
-pair of variables ``(X, Y)`` and a conditioning set ``Z`` (which may be empty):
+Conditional independence (CI) tests are framed as a statistical hypothesis test, with the following null hypothesis for a given
+pair of variables ``(X, Y)`` and a conditioning set ``Z`` (which may be empty). The null hypothesis is that X and Y are statistically
+independent given a conditioning set Z, i.e.,
 
 :math:`H_0: X \perp Y | Z`, or written in terms of their distribution :math:`H_0: P(Y | X, Z) = P(Y | Z)`
 
 Similarly, the alternative hypothesis is written as:
 
-:math:`H_0: X \not\perp Y | Z`, or written in terms of their distribution :math:`H_0: P(Y | X, Z) \neq P(Y | Z)`
+:math:`H_A: X \not\perp Y | Z`, or written in terms of their distribution :math:`H_A: P(Y | X, Z) \neq P(Y | Z)`
 
 Then typically, one posits an acceptable upper bound on the Type I error rate (false positive), typically :math:`\alpha = 0.05`
 and then either attempts to sample from the null distribution, or characterizes the asymptotic distribution
 of the test statistic. In both approaches a pvalue is computed, which is compared to :math:`\alpha`. The pvalue
 states the "probability of observing a test-statistic at least as extreme as our observed test-statistic in null distribution". By rejecting
 the null hypothesis, one claims that :math:`X \not\perp Y | Z`, so that X and Y are in fact (conditionally)
-dependent given Z. Note that if one fails to reject the null hypothesis, it is simply by convention that we
-claim X and Y are conditionally independent. It is not necessarily the case, and it is plausible that there
-is a weak dependency that is unable to be captured by our proposed CI test, and/or data samples.
+dependent given Z.
+
+Note that if one fails to reject the null hypothesis, we cannot accept the alternative hypothesis of
+independence strictly speaking. However, in practice in many settings, such as in causal discovery,
+we would still conclude that they are independent. It is not necessarily the case though, and
+it is plausible that there is a weak dependency that is unable to be captured by our proposed CI test, and/or data samples.
 
 It is because of this reason, one would typically like the most powerful test given assumptions about
 the data. With that in mind, there are various approaches to CI testing that are typically more powerful
@@ -45,7 +53,8 @@ on the underlying distributions. Unfortunately, CMI is notoriously difficult to 
 various proposals in the literature for estimating CMI, which we summarize here:
 
 - The Kraskov, Stogbauer and Grassberger (KSG) estimate approach estimates mutual information
-  via k-NN statistics :footcite:`kraskov_estimating_2004`. It was generalized to CMI by :footcite:`frenzel_partial_2007`.
+  via nearest-neighbor statistics :footcite:`kraskov_estimating_2004`. It computes nearest-neighbors
+  using a kNN algorithm. It was generalized to CMI by :footcite:`frenzel_partial_2007`.
   This class of estimators is asymptotically correct, meaning if we had an infinite amount of data
   we would obtain the true value of the CMI. However, it relies on statistics generated from the k-NN,
   which if we implement the naive approach using a KDTree, then it generally suffers in high-dimensions.
@@ -56,10 +65,10 @@ various proposals in the literature for estimating CMI, which we summarize here:
   and then the CMI value generated from the actual observed data can be compared to the CMI values computed
   on the permutated datasets to estimate a pvalue.
 
-  It is worth noting that if one has "robust" estimates of k-NN using for example a model that
-  is effective in high-dimensions, then the KSG estimator for CMI may be quite good. For example,
+  It is worth noting that if one has good estimates of nearest-neighbors using for example a model that
+  is effective in high-dimensions, then the KSG estimator for CMI may still be effective. For example,
   one can use variants of Random Forests to generate adaptive nearest-neighbor estimates in high-dimensions
-  or on manifolds, such that the KSG estimator is still quite good.
+  or on manifolds, such that the KSG estimator is still powerful.
 
 .. autosummary::
    :toctree: generated/
@@ -81,7 +90,7 @@ Partial (Pearson) Correlation
 -----------------------------
 Partial correlation based on the Pearson correlation is equivalent to CMI in the setting
 of normally distributed data. Computing partial correlation is fast and efficient and
-thus attractive to use. However, this **relies on the assumption of multivariate Gaussianity**,
+thus attractive to use. However, this **relies on the assumption that the variables are Gaussiany**,
 which may be unrealistic in certain datasets.
 
 .. autosummary::
@@ -117,11 +126,19 @@ estimate a pvalue.
 Classifier-based Approaches
 ---------------------------
 Another suite of approaches that rely on permutation testing is the classifier-based approach.
-By shuffling data in an intelligent way, one can setup a hypothesis test for CI based on the
+By shuffling the data, one can setup a hypothesis test for CI based on the
 predicted probabilities from a classification-model. Intuitively, if the shuffled data is similar 
 to the unshuffled data, such that the classification-model achieves non-trivial performance
 (e.g. >50\% accuracy on a balanced dataset), then one fails to reject the null hypothesis and would
 state that the original data was in fact CI :footcite:`Sen2017model`.
+
+When performing marginal independence testing between two sets of variables, ``X`` and ``Y``,
+it is sufficient to shuffle data by just permuting either ``X`` rows or ``Y`` rows uniformly.
+When performing CI testing conditioned on a third set of variables ``Z``, one must perform what is known
+as conditional shuffling. One computes the nearest-neighbors in the ``Z`` subspace and then
+permutes rows based on samples that are close in ``Z`` subspace, which
+helps maintain dependence between (X, Z) and (Y, Z) (if it exists), but generates a
+conditionally independent dataset.
 
 .. autosummary::
    :toctree: generated/

--- a/doc/conditional_independence.rst
+++ b/doc/conditional_independence.rst
@@ -1,0 +1,180 @@
+.. _conditional_independence:
+
+========================
+Conditional Independence
+========================
+
+.. currentmodule:: dodiscover.ci
+
+Testing for invariances in the data, such as conditional independence (CI) can be represented graphically
+in the form of d-separation statements under the causal faithfulness assumption. Given this, one
+is interested in high-powered and well-controlled CI tests that can be used to test for CI in data.
+
+CI tests are framed as a statistical hypothesis test, with the following null hypothesis for a given
+pair of variables ``(X, Y)`` and a conditioning set ``Z`` (which may be empty):
+
+:math:`H_0: X \perp Y | Z`, or written in terms of their distribution :math:`H_0: P(Y | X, Z) = P(Y | Z)`
+
+Similarly, the alternative hypothesis is written as:
+
+:math:`H_0: X \not\perp Y | Z`, or written in terms of their distribution :math:`H_0: P(Y | X, Z) \neq P(Y | Z)`
+
+Then typically, one posits an acceptable Type I error rate (false positive), typically :math:`\alpha = 0.05`
+and then either attempts to sample from the null distribution, or characterizes the asymptotic distribution
+of the test statistic. In both approaches a pvalue is computed, which is compared to :math:`\alpha`. The pvalue
+states the "probability that we observe our data (e.g. test statistic) under the null hypothesis". By rejecting
+the null hypothesis, one claims that :math:`X \not\perp Y | Z`, so that X and Y are in fact (conditionally)
+dependent given Z. Note that if one fails to reject the null hypothesis, it is simply by convention that we
+claim X and Y are conditionally independent. It is not necessarily the case, and it is plausible that there
+is a weak dependency that is unable to be captured by our proposed CI test, and/or data samples.
+
+It is because of this reason, one would typically like the most powerful test given assumptions about
+the data. With that in mind, there are various approaches to CI testing that are typically more powerful
+with certain assumptions on the underlying data distribution.
+
+Conditional Mutual Information
+------------------------------
+Conditional mutual information (CMI) is a general formulation of CI, where CMI is defined as
+:math::
+    
+    \\int log \frac{p(x, y | z)}{p(x | z) p(y | z)}
+
+As we can see, CMI is equal to 0, if and only if :math:`p(x, y | z) = p(x | z) p(y | z)`, which
+is exactly the definition of CI. CMI is completely non-parametric and thus requires no assumptions
+on the underlying distributions. Unfortunately, CMI is notoriously difficult to estimate. There are
+various proposals in the literature for estimating CMI, which we summarize here:
+
+- The Kraskov, Stogbauer and Grassberger (KSG) estimate approach estimates mutual information
+  via k-NN statistics :footcite:`kraskov_estimating_2004`. It was generalized to CMI by :footcite:`frenzel_partial_2007`.
+  This class of estimators is asymptotically correct, meaning if we had an infinite amount of data
+  we would obtain the true value of the CMI. However, it relies on statistics generated from the k-NN,
+  which if we implement the naive approach using a KDTree, then it generally suffers in high-dimensions.
+  In our examples, we see it suffer with dimensionality > 4 or 5.
+
+  Estimates of CMI can be converted into a CI hypothesis test by permutation testing :footcite:`Runge2018cmi`.
+  One can generate estimated samples from the null distribution by permuting samples in an intelligent manner
+  and then the CMI value generated from the actual observed data can be compared to the CMI values computed
+  on the permutated datasets to estimate a pvalue.
+
+  It is worth noting that if one has "robust" estimates of k-NN using for example a model that
+  is effective in high-dimensions, then the KSG estimator for CMI may be quite good. For example,
+  one can use variants of Random Forests to generate adaptive nearest-neighbor estimates in high-dimensions
+  or on manifolds, such that the KSG estimator is still quite good.
+
+.. autosummary::
+   :toctree: generated/
+
+    CMITest
+
+- The Classifier Divergence approach estimates CMI using a classification model.
+
+.. autosummary::
+   :toctree: generated/
+
+    ClassifierCMITest
+
+- Direct posterior estimates can be implemented with a classification model by directly
+  estimating :math:`P(y|x)` and :math:`P(y|x,z)`, which can be used as plug-in estimates
+  to the equation for CMI.
+
+Partial (Pearson) Correlation
+-----------------------------
+Partial correlation based on the Pearson correlation is equivalent to CMI in the setting
+of normally distributed data. Computing partial correlation is fast and efficient and
+thus attractive to use. However, this **relies on the assumption of multivariate Gaussianity**,
+which may be unrealistic in certain datasets.
+
+.. autosummary::
+   :toctree: generated/
+
+    FisherZCITest
+
+Discrete, Categorical and Binary Data
+-------------------------------------
+If one has discrete data, then the test to use is based on Chi-square tests. The :math:`G^2`
+class of tests will construct a contingency table based on the number of levels across
+each discrete variable. An exponential amount of data is needed for increasing levels
+for a discrete variable.
+
+.. autosummary::
+   :toctree: generated/
+
+    GSquareCITest
+
+Kernel-Approaches
+-----------------
+Kernel-based tests are attractive since they are semi-parametric and use kernel-based ideas
+that have been shown to be robust in the machine-learning field. The Kernel CI test is a test
+that computes a test statistic from kernels of the data and uses permutation testing to
+generate samples from the null distribution :footcite:`Zhang2011`, which are then used to
+estimate a pvalue.
+
+.. autosummary::
+   :toctree: generated/
+
+    KernelCITest
+
+Classifier-based Approaches
+---------------------------
+Another suite of approaches that rely on permutation testing is the classifier-based approach.
+By shuffling data in an intelligent way, one can setup a hypothesis test for CI based on the
+predicted probabilities from a classification-model. Intuitively, if the shuffled data is similar 
+to the unshuffled data, such that the classification-model achieves non-trivial performance
+(e.g. >50\% accuracy on a balanced dataset), then one fails to reject the null hypothesis and would
+state that the original data was in fact CI :footcite:`Sen2017model`.
+
+.. autosummary::
+   :toctree: generated/
+
+    ClassifierCITest
+
+=======================
+Conditional Discrepancy
+=======================
+
+.. currentmodule:: dodiscover.cd
+
+Conditional discrepancy (CD) is another form of conditional invariances that may be exhibited by data. The
+general question is whether or not the following two distributions are equal:
+
+:math:`P_{i=j}(y|x) =? P_{i=k}(y|x)`
+
+where :math:`P_i(.)` denote the distribution that explicitly comes from
+a different group, or environment, denoted by the discrete indices :math:`i`. This is also
+known in some cases as conditional k-sample testing, if there are a finite k number of groups
+for :math:`P_i`. CD testing is important because it detects other kinds of invariances besides
+CI. 
+
+Discrete, Categorical and Binary Data
+-------------------------------------
+If one has entirely discrete data, then the problem of CD can be converted into a CI test that
+leverages the Chi-square class of tests. Since ``y`` and ``x`` are discrete and so are the
+indices of the distribution, one can convert the CD test:
+
+:math:`P_{i=j}(y|x) =? P_{i=k}(y|x)` into the CI test :math:`P(y|x,i) = P(y|x)`, which can
+be tested with the Chi-square CI tests.
+
+Kernel-Approaches
+-----------------
+Kernel-based tests are attractive since they are semi-parametric and use kernel-based ideas
+that have been shown to be robust in the machine-learning field. The Kernel CD test is a test
+that computes a test statistic from kernels of the data and uses a weighted permutation testing
+based on the estimated propensity scores to generate samples from the null distribution
+:footcite:`Park2021conditional`, which are then used to estimate a pvalue.
+
+.. autosummary::
+   :toctree: generated/
+
+    KernelCDTest
+
+Bregman-Divergences
+-------------------
+The Bregman CD test is a divergence-based test
+that computes a test statistic from estimated Von-Neumann divergences of the data and uses a
+weighted permutation testing based on the estimated propensity scores to generate samples from the null distribution
+:footcite:`Yu2020Bregman`, which are then used to estimate a pvalue.
+
+.. autosummary::
+   :toctree: generated/
+
+    BregmanCDTest

--- a/doc/conditional_independence.rst
+++ b/doc/conditional_independence.rst
@@ -19,10 +19,10 @@ Similarly, the alternative hypothesis is written as:
 
 :math:`H_0: X \not\perp Y | Z`, or written in terms of their distribution :math:`H_0: P(Y | X, Z) \neq P(Y | Z)`
 
-Then typically, one posits an acceptable Type I error rate (false positive), typically :math:`\alpha = 0.05`
+Then typically, one posits an acceptable upper bound on the Type I error rate (false positive), typically :math:`\alpha = 0.05`
 and then either attempts to sample from the null distribution, or characterizes the asymptotic distribution
 of the test statistic. In both approaches a pvalue is computed, which is compared to :math:`\alpha`. The pvalue
-states the "probability that we observe our data (e.g. test statistic) under the null hypothesis". By rejecting
+states the "probability of observing a test-statistic at least as extreme as our observed test-statistic in null distribution". By rejecting
 the null hypothesis, one claims that :math:`X \not\perp Y | Z`, so that X and Y are in fact (conditionally)
 dependent given Z. Note that if one fails to reject the null hypothesis, it is simply by convention that we
 claim X and Y are conditionally independent. It is not necessarily the case, and it is plausible that there

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,10 @@ extensions = [
     "numpydoc",
     "IPython.sphinxext.ipython_console_highlighting",
     "nbsphinx",
+    "sphinx.ext.graphviz",
 ]
+
+graphviz_output_format = "png"
 
 # configure sphinx-copybutton
 copybutton_prompt_text = r">>> |\.\.\. |\$ "
@@ -111,6 +114,7 @@ numpydoc_xref_ignore = {
     "CPDAG",
     "PAG",
     "ADMG",
+    "PsiFCI",
     # networkx
     "node",
     "nodes",
@@ -148,6 +152,7 @@ numpydoc_xref_aliases = {
     "nx.Graph": "networkx.Graph",
     "nx.DiGraph": "networkx.DiGraph",
     "nx.MultiDiGraph": "networkx.MultiDiGraph",
+    "nx": "networkx",
     "pgmpy.models.BayesianNetwork": "pgmpy.models.BayesianNetwork",
     # dodiscover
     "ADMG": "dodiscover.ADMG",
@@ -155,6 +160,8 @@ numpydoc_xref_aliases = {
     "CPDAG": "dodiscover.CPDAG",
     "DAG": "dodiscover.DAG",
     "BaseConditionalIndependenceTest": "dodiscover.ci.BaseConditionalIndependenceTest",
+    "BaseConditionalDiscrepancyTest": "dodiscover.cd.BaseConditionalDiscrepancyTest",
+    "ConditioningSetSelection": "dodiscover.constraint.ConditioningSetSelection",
     "Context": "dodiscover.context.Context",
     "PC": "dodiscover.PC",
     "EquivalenceClass": "dodiscover.EquivalenceClass",
@@ -173,7 +180,7 @@ numpydoc_xref_aliases = {
     "column": "pandas.DataFrame.columns",
 }
 
-default_role = "py:obj"
+default_role = "literal"
 
 # Tell myst-parser to assign header anchors for h1-h3.
 # myst_heading_anchors = 3
@@ -207,6 +214,7 @@ intersphinx_mapping = {
     "joblib": ("https://joblib.readthedocs.io/en/latest", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "torch": ("https://pytorch.org/docs/master/", None),
+    "pywhy_graphs": ("https://www.pywhy.org/pywhy-graphs/dev/", None),
 }
 intersphinx_timeout = 5
 
@@ -255,6 +263,13 @@ html_theme_options = {
 }
 
 scrapers = ("matplotlib",)
+# Add pygraphviz png scraper, if available
+try:
+    from pygraphviz.scraper import PNGScraper
+
+    scrapers += (PNGScraper(),)
+except ImportError:
+    pass
 
 sphinx_gallery_conf = {
     "doc_module": "dodiscover",

--- a/doc/constraint_causal_discovery.rst
+++ b/doc/constraint_causal_discovery.rst
@@ -33,10 +33,14 @@ may be familiar with.
 On the other hand, the causal faithfulness assumption states that all
 CI statements in the data map to a d-separation statement. That is, there are no accidental
 CI that occur in the data, which are not represented by a d-separation statement in the underlying
-causal graph. The causal faithfulness assumption is a very problematic assumption because in practice
+causal graph. The causal faithfulness assumption in theory is not an issue due to a theoretical result
+showing that violations of faithfulness in causal diagrams have measure zero (i.e. they do not occur).
+
+However, in practice the causal faithfulness assumption is a very problematic assumption because 
 one might have data that is very weakly dependent, such that a CI test under a specified :math:`\alpha`
-level would fail to reject the null hypothesis and conclude the variables in question are CI. In higher
-dimensions this can occur a large percentage of the time as demonstrated in :footcite:`uhler2013geometry`.
+level would fail to reject the null hypothesis and conclude the variables in question are CI. violations
+of "strong-faithfulness" occurs frequently and almost surely in higher
+dimensions :footcite:`uhler2013geometry`.
 
 Tackling violations of faithfulness in constraint-based causal discovery is a large and active
 area of research.

--- a/doc/constraint_causal_discovery.rst
+++ b/doc/constraint_causal_discovery.rst
@@ -109,11 +109,6 @@ Alternatively, one may assume they do not know where the intervention was applie
 distribution. In this case, one may apply the :math:`Psi`-FCI algorithm to learn a
 :math:`Psi`-PAG :footcite:`Jaber2020causal`.
 
-.. autosummary::
-   :toctree: generated/
-
-    constraint.PsiFCI
-
 Choosing the conditioning sets
 ------------------------------
 We briefly describe how ``dodiscover`` chooses conditioning sets, ``Z`` that are tested given

--- a/doc/constraint_causal_discovery.rst
+++ b/doc/constraint_causal_discovery.rst
@@ -8,10 +8,14 @@ Constraint-based causal discovery
     :no-inherited-members:
 .. currentmodule:: dodiscover
 
+Testing for invariances in the data, such as conditional independence (CI) can be represented graphically
+in the form of d-separation statements under the causal faithfulness assumption. Given this, one
+is interested in high-powered and well-controlled CI tests that can be used to test for CI in data.
+
 The following are a set of methods intended for (non-parametric) structure learning
 of causal graphs (i.e. causal discovery) given observational and/or interventional data
-by checking constraints in the form of conditional independences (CI). At a high level
-all constraint-based causal discovery, tests CI statements, where we use different CI
+by checking constraints in the form of conditional independences (CI). At a high level, all constraint-based
+causal discovery algorithms test CI statements, where we use different CI
 statistical tests to test the following null hypothesis:
 
 :math:`H_0: X \perp Y | Z` and :math:`H_A: X \not\perp Y | Z`
@@ -26,9 +30,9 @@ Fundamental Assumptions of Constraint-Based Causal Discovery
 The fundamental assumptions of all algorithms in this section are the Markov property assumption
 and the causal faithfulness assumption :footcite:`Spirtes1993` and :footcite:`Pearl_causality_2009`.
 
-The Markov assumption states that all d-separation statements in the causal graph imply a
-corresponding CI statement in the data. This is a core-assumption that users from graphical modeling
-may be familiar with.
+The Markov assumption states that any d-separation statement implies a CI statement. This is a
+core-assumption that users from graphical modeling may be familiar with. It is a
+general assumption that connects graphical models to probabilistic models.
 
 On the other hand, the causal faithfulness assumption states that all
 CI statements in the data map to a d-separation statement. That is, there are no accidental

--- a/doc/constraint_causal_discovery.rst
+++ b/doc/constraint_causal_discovery.rst
@@ -1,0 +1,137 @@
+.. _constraint_causal_discovery:
+
+==================================
+Constraint-based causal discovery
+==================================
+.. automodule:: dodiscover.constraint
+    :no-members:
+    :no-inherited-members:
+.. currentmodule:: dodiscover
+
+The following are a set of methods intended for (non-parametric) structure learning
+of causal graphs (i.e. causal discovery) given observational and/or interventional data
+by checking constraints in the form of conditional independences (CI). At a high level
+all constraint-based causal discovery, tests CI statements, where we use different CI
+statistical tests to test the following null hypothesis:
+
+:math:`H_0: X \perp Y | Z` and :math:`H_A: X \not\perp Y | Z`
+
+For a given node ``X`` and ``Y`` in the underlying causal graph of interest, and
+a conditioning set, ``Z``. CI tests can have a variety of different assumptions
+that make one better than another in different settings and data assumptions.
+For more information on the CI tests themselves, see :ref:`conditional_independence`.
+
+Fundamental Assumptions of Constraint-Based Causal Discovery
+------------------------------------------------------------
+The fundamental assumptions of all algorithms in this section are the Markov property assumption
+and the causal faithfulness assumption :footcite:`Spirtes1993` and :footcite:`Pearl_causality_2009`.
+
+The Markov assumption states that all d-separation statements in the causal graph imply a
+corresponding CI statement in the data. This is a core-assumption that users from graphical modeling
+may be familiar with.
+
+On the other hand, the causal faithfulness assumption states that all
+CI statements in the data map to a d-separation statement. That is, there are no accidental
+CI that occur in the data, which are not represented by a d-separation statement in the underlying
+causal graph. The causal faithfulness assumption is a very problematic assumption because in practice
+one might have data that is very weakly dependent, such that a CI test under a specified :math:`\alpha`
+level would fail to reject the null hypothesis and conclude the variables in question are CI. In higher
+dimensions this can occur a large percentage of the time as demonstrated in :footcite:`uhler2013geometry`.
+
+Tackling violations of faithfulness in constraint-based causal discovery is a large and active
+area of research.
+
+(Non-parametric) Markovian SCMs with Observational Data
+-------------------------------------------------------
+If one assumes that the underlying structural causal model (SCM) is Markovian,
+then the Peter and Clarke (PC) algorithm has been shown to be sound and complete
+for learning a completed partially directed acyclic graph (CPDAG) :footcite:`Meek1995`.
+
+The :class:`dodiscover.constraint.PC` algorithm and its variants assume Markovianity, which is
+also known as causal-sufficiency in the literature. In other words, it assumes a lack of latent
+confounders, where there is no latent variable that is a confounder of the observed data.
+
+The PC algorithm learns a CPDAG in three stages:
+
+1. skeleton discovery: This first phase is the process of leveraging CI tests to test
+    edges for conditional independence. Along the way, connections of the graph are trimmed
+    (when CI is detected) and the separating sets among pairs of variables are tracked.
+
+    A separating set is a set of nodes in the graph that d-separate a pair of variables.
+    Note that a pair of variables may contain many d-separators, and thus there may be
+    many separating sets.
+2. unshielded triplet orientation: This takes triplets on a path of the form ``X *-* Y *-* Z``,
+    where the triplet path is "unshielded" meaning ``X`` and ``Z`` are not connected. Then
+    it checks that ``Y`` is not in the separating set of X and Z. Given these two conditions,
+    Y must be a collider and is oriented as ``X *-> Y <-* Z``. The stars in the path indicate
+    that it can be any kind of edge endpoint (e.g. in a PAG it could be a circle endpoint edge).
+3. deterministic path orientations: Once all colliders are oriented, there are a set of
+    deterministic logical rules that allow us to orient more edges. In the PC algorithm,
+    these are the so-called "Meek's orientation rules", which are 4 rules that are applied
+    repeatedly until no more changes to the graph are made :footcite:`Meek1995`.
+
+The resulting graph is an equivalence class of DAGs without latent confounders, the CPDAG.
+For more information on CPDAGs, one can also see :class:`pywhy_graphs.CPDAG`.
+
+(Non-parametric) Semi-Markovian SCMs with Observational Data
+------------------------------------------------------------
+If one assumes that the underlying SCM is Semi-Markovian, then the "Fast Causal Inference"
+(FCI) algorithm has been shown to be sound and complete for learning a partial ancestral
+graph (PAG) :footcite:`zhang2008ancestralgraphs,Zhang2008`.
+
+The FCI algorithm and its variants assume Semi-Markovianity, which assumes the
+possible presence of latent confounders and even selection bias in the observational data.
+
+The :class:`dodiscover.constraint.FCI` algorithm follows the three stages of learning that the PC
+algorithm does, but with a few minor modifications that we will outline here:
+
+1. skeleton discovery: The skeleton discovery phase is now composed of two stages. The first
+    stage is the same as the PC algorithm. The second phase, takes the output graph of the first
+    phase and tries to orient colliders. This results in a PAG that can be queried for the
+    potentially d-separating (PDS) sets for any pair of variables ``(X, Y)``. The skeleton
+    discovery phase is restarted from scratch, but now the conditioning sets are chosen from
+    the PDS sets. The PDS set approach is described in :footcite:`Colombo2012` and
+    :footcite:`Spirtes1993`.
+2. deterministic path orientations: The four orientation rules of the PC algorithm are still
+    the same, but in the FCI case, we add an additional six orientation rules. The additional
+    rules account for latent confounding and selection bias. Three of those rules
+    only apply if we assume selection bias is present.
+
+(Non-parametric) SCMs with Interventional Data
+----------------------------------------------
+When we have access to experimental data, there are multiple datasets corresponding to multiple
+distributions (e.g. observational and different interventions), we can improve causal discovery.
+If one assumes we have access to multiple distributions, one may know the targets of
+each intervention, where one can apply the I-FCI algorithm to learn an Interventional-PAG
+(I-PAG) :footcite:`Kocaoglu2019characterization`.
+
+Alternatively, one may assume they do not know where the intervention was applied in each
+distribution. In this case, one may apply the :math:`Psi`-FCI algorithm to learn a
+:math:`Psi`-PAG :footcite:`Jaber2020causal`.
+
+.. autosummary::
+   :toctree: generated/
+
+    constraint.PsiFCI
+
+Choosing the conditioning sets
+------------------------------
+We briefly describe how ``dodiscover`` chooses conditioning sets, ``Z`` that are tested given
+a pair of nodes ``(X, Y)``. The test we are doing is :math:`X \perp Y | Z`, where ``Z`` can
+be the empty set. There are multiple strategies for choosing ``Z``.
+
+.. autosummary::
+   :toctree: generated/
+
+   constraint.ConditioningSetSelection
+
+Hyperparameters and controlling overfitting
+-------------------------------------------
+To describe.
+
+Robust learning
+---------------
+Conservative orientations, etc.
+
+
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,12 @@ algorithms and data structures of ``networkx``.
 We encourage you to use the package for your causal inference research and also build on top
 with relevant Pull Requests.
 
-See our examples for walk-throughs of how to use the package.
+See our examples for walk-throughs of how to use the package, or 
+
+Please refer to our :ref:`user_guide` for details on all the tools that we
+provide. You can also find an exhaustive list of the public API in the
+:ref:`api_ref`. You can also look at our numerous :ref:`examples <general_examples>`
+that illustrate the use of ``dodiscover`` in many different contexts.
 
 Contents
 --------
@@ -19,8 +24,9 @@ Contents
    :caption: Getting started:
 
    installation
-   api
-   use
+   Reference API<api>
+   Usage<use>
+   User Guide<user_guide>
    tutorials/index
    whats_new
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -143,7 +143,6 @@
 @article{cressieread1984,
   issn      = {00359246},
   url       = {http://www.jstor.org/stable/2345686},
-  abstract  = {This article investigates the family {Iλ;λ ∈ R} of power divergence statistics for testing the fit of observed frequencies {Xi;i = 1,...,k} to expected frequencies {Ei;i = 1,...,k}. From the definition 2nIλ = 2/λ(λ + 1) ∑ki = 1 Xi{(Xi/Ei)λ - 1}; λ ∈ R, it can easily be seen that Pearson's X2 (λ = 1), the log likelihood ratio statistic (λ = 0), the Freeman-Tukey statistic (λ = -1/2) the modified log likelihood ratio statistic (λ = -1) and the Neyman modified X2 (λ = -2), are all special cases. Most of the work presented is devoted to an analytic study of the asymptotic difference between different Iλ, however finite sample results have been presented as a check and a supplement to our conclusions. A new goodness-of-fit statistic, where λ = 2/3, emerges as an excellent and compromising alternative to the old warriors, I0 and I1.},
   author    = {Noel Cressie and Timothy R. C. Read},
   journal   = {Journal of the Royal Statistical Society. Series B (Methodological)},
   number    = {3},
@@ -161,7 +160,6 @@
   title    = {Partial {Mutual} {Information} for {Coupling} {Analysis} of {Multivariate} {Time} {Series}},
   volume   = {99},
   doi      = {10.1103/PhysRevLett.99.204101},
-  abstract = {We propose a method to discover couplings in multivariate time series, based on partial mutual information, an information-theoretic generalization of partial correlation. It represents the part of mutual information of two random quantities that is not contained in a third one. By suitable choice of the latter, we can differentiate between direct and indirect interactions and derive an appropriate graphical model. An efficient estimator for partial mutual information is presented as well.},
   journal  = {Physical review letters},
   author   = {Frenzel, Stefan and Pompe, Bernd},
   month    = dec,
@@ -175,7 +173,6 @@
   volume   = {69},
   url      = {https://link.aps.org/doi/10.1103/PhysRevE.69.066138},
   doi      = {10.1103/PhysRevE.69.066138},
-  abstract = {We present two classes of improved estimators for mutual information M(X,Y), from samples of random points distributed according to some joint probability density μ(x,y). In contrast to conventional estimators based on binnings, they are based on entropy estimates from k-nearest neighbor distances. This means that they are data efficient (with k=1 we resolve structures down to the smallest possible scales), adaptive (the resolution is higher where data are more numerous), and have minimal bias. Indeed, the bias of the underlying entropy estimates is mainly due to nonuniformity of the density at the smallest resolved scale, giving typically systematic errors which scale as functions of k∕N for N points. Numerically, we find that both families become exact for independent distributions, i.e. the estimator ˆM(X,Y) vanishes (up to statistical fluctuations) if μ(x,y)=μ(x)μ(y). This holds for all tested marginal distributions and for all dimensions of x and y. In addition, we give estimators for redundancies between more than two random variables. We compare our algorithms in detail with existing algorithms. Finally, we demonstrate the usefulness of our estimators for assessing the actual independence of components obtained from independent component analysis (ICA), for improving ICA, and for estimating the reliability of blind source separation., This article appears in the following collections:},
   number   = {6},
   urldate  = {2023-01-27},
   journal  = {Physical Review E},
@@ -277,6 +274,5 @@
   doi      = {10.1126/science.1105809},
   url      = {https://www.science.org/doi/abs/10.1126/science.1105809},
   eprint   = {https://www.science.org/doi/pdf/10.1126/science.1105809},
-  abstract = {Machine learning was applied for the automated derivation of causal influences in cellular signaling networks. This derivation relied on the simultaneous measurement of multiple phosphorylated protein and phospholipid components in thousands of individual primary human immune system cells. Perturbing these cells with molecular interventions drove the ordering of connections between pathway components, wherein Bayesian network computational methods automatically elucidated most of the traditionally reported signaling relationships and predicted novel interpathway network causalities, which we verified experimentally. Reconstruction of network models from physiologically relevant primary single cells might be applied to understanding native-state tissue signaling biology, complex drug actions, and dysfunctional signaling in diseased cells.}
 }
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -16,11 +16,31 @@
   url       = {https://doi.org/10.1214/11-AOS940}
 }
 
-@article{Lopez2016revisiting,
-  title   = {Revisiting classifier two-sample tests},
-  author  = {Lopez-Paz, David and Oquab, Maxime},
-  journal = {arXiv preprint arXiv:1610.06545},
-  year    = {2016}
+@inproceedings{correa2020calculus,
+  title     = {A calculus for stochastic interventions: Causal effect identification and surrogate experiments},
+  author    = {Correa, Juan and Bareinboim, Elias},
+  booktitle = {Proceedings of the AAAI conference on artificial intelligence},
+  volume    = {34},
+  number    = {06},
+  pages     = {10093--10100},
+  year      = {2020}
+}
+
+@article{Jaber2020causal,
+  title   = {Causal discovery from soft interventions with unknown targets: Characterization and learning},
+  author  = {Jaber, Amin and Kocaoglu, Murat and Shanmugam, Karthikeyan and Bareinboim, Elias},
+  journal = {Advances in neural information processing systems},
+  volume  = {33},
+  pages   = {9551--9561},
+  year    = {2020}
+}
+
+@article{Kocaoglu2019characterization,
+  title   = {Characterization and learning of causal graphs with latent variables from soft interventions},
+  author  = {Kocaoglu, Murat and Jaber, Amin and Shanmugam, Karthikeyan and Bareinboim, Elias},
+  journal = {Advances in Neural Information Processing Systems},
+  volume  = {32},
+  year    = {2019}
 }
 
 @article{Meek1995,
@@ -31,15 +51,6 @@
   title   = {Causal Inference and Causal Explanation with Background Knowledge},
   volume  = {2},
   journal = {Proceedings of Eleventh Conference on Uncertainty in Artificial Intelligence, Montreal, QU}
-}
-
-@inproceedings{Mukherjee2020ccmi,
-  title        = {CCMI: Classifier based conditional mutual information estimation},
-  author       = {Mukherjee, Sudipto and Asnani, Himanshu and Kannan, Sreeram},
-  booktitle    = {Uncertainty in artificial intelligence},
-  pages        = {1083--1093},
-  year         = {2020},
-  organization = {PMLR}
 }
 
 @book{Neapolitan2003,
@@ -53,6 +64,144 @@
   doi       = {10.1145/1327942.1327961}
 }
 
+@article{uhler2013geometry,
+  title     = {Geometry of the faithfulness assumption in causal inference},
+  author    = {Uhler, Caroline and Raskutti, Garvesh and B{\"u}hlmann, Peter and Yu, Bin},
+  journal   = {The Annals of Statistics},
+  pages     = {436--463},
+  year      = {2013},
+  publisher = {JSTOR}
+}
+
+@article{Zhang2008,
+  title    = {On the completeness of orientation rules for causal discovery in the presence of latent confounders and selection bias},
+  journal  = {Artificial Intelligence},
+  volume   = {172},
+  number   = {16},
+  pages    = {1873-1896},
+  year     = {2008},
+  issn     = {0004-3702},
+  doi      = {https://doi.org/10.1016/j.artint.2008.08.001},
+  url      = {https://www.sciencedirect.com/science/article/pii/S0004370208001008},
+  author   = {Jiji Zhang},
+  keywords = {Ancestral graphs, Automated causal discovery, Bayesian networks, Causal models, Markov equivalence, Latent variables}
+}
+
+@article{zhang2008ancestralgraphs,
+  author  = {Jiji Zhang},
+  title   = {Causal Reasoning with Ancestral Graphs},
+  journal = {Journal of Machine Learning Research},
+  year    = {2008},
+  volume  = {9},
+  number  = {47},
+  pages   = {1437--1474},
+  url     = {http://jmlr.org/papers/v9/zhang08a.html}
+}
+
+# Books
+
+@book{Pearl_causality_2009,
+  author    = {Pearl, Judea},
+  title     = {Causality: Models, Reasoning and Inference},
+  year      = {2009},
+  isbn      = {052189560X},
+  publisher = {Cambridge University Press},
+  address   = {USA},
+  edition   = {2nd}
+}
+
+@book{Spirtes1993,
+  author    = {Spirtes, Peter and Glymour, Clark and Scheines, Richard},
+  year      = {1993},
+  month     = {01},
+  pages     = {},
+  title     = {Causation, Prediction, and Search},
+  volume    = {81},
+  isbn      = {978-1-4612-7650-0},
+  doi       = {10.1007/978-1-4612-2748-9},
+  publisher = {The MIT Press}
+}
+
+@article{xie2020generalized,
+  title   = {Generalized independent noise condition for estimating latent variable causal graphs},
+  author  = {Xie, Feng and Cai, Ruichu and Huang, Biwei and Glymour, Clark and Hao, Zhifeng and Zhang, Kun},
+  journal = {Advances in Neural Information Processing Systems},
+  volume  = {33},
+  pages   = {14891--14902},
+  year    = {2020}
+}
+
+@article{dai2022independence,
+  title   = {Independence Testing-Based Approach to Causal Discovery under Measurement Error and Linear Non-Gaussian Models},
+  author  = {Dai, Haoyue and Spirtes, Peter and Zhang, Kun},
+  journal = {arXiv preprint arXiv:2210.11021},
+  year    = {2022}
+}
+
+% Conditional Testing
+
+@article{cressieread1984,
+  issn      = {00359246},
+  url       = {http://www.jstor.org/stable/2345686},
+  abstract  = {This article investigates the family {Iλ;λ ∈ R} of power divergence statistics for testing the fit of observed frequencies {Xi;i = 1,...,k} to expected frequencies {Ei;i = 1,...,k}. From the definition 2nIλ = 2/λ(λ + 1) ∑ki = 1 Xi{(Xi/Ei)λ - 1}; λ ∈ R, it can easily be seen that Pearson's X2 (λ = 1), the log likelihood ratio statistic (λ = 0), the Freeman-Tukey statistic (λ = -1/2) the modified log likelihood ratio statistic (λ = -1) and the Neyman modified X2 (λ = -2), are all special cases. Most of the work presented is devoted to an analytic study of the asymptotic difference between different Iλ, however finite sample results have been presented as a check and a supplement to our conclusions. A new goodness-of-fit statistic, where λ = 2/3, emerges as an excellent and compromising alternative to the old warriors, I0 and I1.},
+  author    = {Noel Cressie and Timothy R. C. Read},
+  journal   = {Journal of the Royal Statistical Society. Series B (Methodological)},
+  number    = {3},
+  pages     = {440--464},
+  publisher = {[Royal Statistical Society, Wiley]},
+  title     = {Multinomial Goodness-of-Fit Tests},
+  urldate   = {2023-03-16},
+  volume    = {46},
+  year      = {1984}
+}
+
+
+
+@article{frenzel_partial_2007,
+  title    = {Partial {Mutual} {Information} for {Coupling} {Analysis} of {Multivariate} {Time} {Series}},
+  volume   = {99},
+  doi      = {10.1103/PhysRevLett.99.204101},
+  abstract = {We propose a method to discover couplings in multivariate time series, based on partial mutual information, an information-theoretic generalization of partial correlation. It represents the part of mutual information of two random quantities that is not contained in a third one. By suitable choice of the latter, we can differentiate between direct and indirect interactions and derive an appropriate graphical model. An efficient estimator for partial mutual information is presented as well.},
+  journal  = {Physical review letters},
+  author   = {Frenzel, Stefan and Pompe, Bernd},
+  month    = dec,
+  year     = {2007},
+  pages    = {204101},
+  file     = {Full Text PDF:/Users/adam2392/Zotero/storage/8ICFXVZG/Frenzel and Pompe - 2007 - Partial Mutual Information for Coupling Analysis o.pdf:application/pdf}
+}
+
+@article{kraskov_estimating_2004,
+  title    = {Estimating mutual information},
+  volume   = {69},
+  url      = {https://link.aps.org/doi/10.1103/PhysRevE.69.066138},
+  doi      = {10.1103/PhysRevE.69.066138},
+  abstract = {We present two classes of improved estimators for mutual information M(X,Y), from samples of random points distributed according to some joint probability density μ(x,y). In contrast to conventional estimators based on binnings, they are based on entropy estimates from k-nearest neighbor distances. This means that they are data efficient (with k=1 we resolve structures down to the smallest possible scales), adaptive (the resolution is higher where data are more numerous), and have minimal bias. Indeed, the bias of the underlying entropy estimates is mainly due to nonuniformity of the density at the smallest resolved scale, giving typically systematic errors which scale as functions of k∕N for N points. Numerically, we find that both families become exact for independent distributions, i.e. the estimator ˆM(X,Y) vanishes (up to statistical fluctuations) if μ(x,y)=μ(x)μ(y). This holds for all tested marginal distributions and for all dimensions of x and y. In addition, we give estimators for redundancies between more than two random variables. We compare our algorithms in detail with existing algorithms. Finally, we demonstrate the usefulness of our estimators for assessing the actual independence of components obtained from independent component analysis (ICA), for improving ICA, and for estimating the reliability of blind source separation., This article appears in the following collections:},
+  number   = {6},
+  urldate  = {2023-01-27},
+  journal  = {Physical Review E},
+  author   = {Kraskov, Alexander and Stögbauer, Harald and Grassberger, Peter},
+  month    = jun,
+  year     = {2004},
+  note     = {Publisher: American Physical Society},
+  pages    = {066138},
+  file     = {APS Snapshot:/Users/adam2392/Zotero/storage/GRW23BYU/PhysRevE.69.html:text/html;Full Text PDF:/Users/adam2392/Zotero/storage/NJT9QCVA/Kraskov et al. - 2004 - Estimating mutual information.pdf:application/pdf}
+}
+
+@article{Lopez2016revisiting,
+  title   = {Revisiting classifier two-sample tests},
+  author  = {Lopez-Paz, David and Oquab, Maxime},
+  journal = {arXiv preprint arXiv:1610.06545},
+  year    = {2016}
+}
+
+@inproceedings{Mukherjee2020ccmi,
+  title        = {CCMI: Classifier based conditional mutual information estimation},
+  author       = {Mukherjee, Sudipto and Asnani, Himanshu and Kannan, Sreeram},
+  booktitle    = {Uncertainty in artificial intelligence},
+  pages        = {1083--1093},
+  year         = {2020},
+  organization = {PMLR}
+}
 
 @inproceedings{Park2021conditional,
   title        = {Conditional distributional treatment effect with kernel conditional mean embeddings and U-statistic regression},
@@ -62,7 +211,6 @@
   year         = {2021},
   organization = {PMLR}
 }
-
 
 @inproceedings{Runge2018cmi,
   title     = {Conditional independence testing based on a nearest-neighbor estimator of conditional mutual information},
@@ -102,20 +250,6 @@
   url       = {https://doi.org/10.24963/ijcai.2020/385}
 }
 
-@article{Zhang2008,
-  title    = {On the completeness of orientation rules for causal discovery in the presence of latent confounders and selection bias},
-  journal  = {Artificial Intelligence},
-  volume   = {172},
-  number   = {16},
-  pages    = {1873-1896},
-  year     = {2008},
-  issn     = {0004-3702},
-  doi      = {https://doi.org/10.1016/j.artint.2008.08.001},
-  url      = {https://www.sciencedirect.com/science/article/pii/S0004370208001008},
-  author   = {Jiji Zhang},
-  keywords = {Ancestral graphs, Automated causal discovery, Bayesian networks, Causal models, Markov equivalence, Latent variables}
-}
-
 @inproceedings{Zhang2011,
   author    = {Zhang, Kun and Peters, Jonas and Janzing, Dominik and Sch\"{o}lkopf, Bernhard},
   title     = {Kernel-Based Conditional Independence Test and Application in Causal Discovery},
@@ -130,42 +264,19 @@
   series    = {UAI'11}
 }
 
-# Books
+% Example refs
 
-@book{Pearl_causality_2009,
-  author    = {Pearl, Judea},
-  title     = {Causality: Models, Reasoning and Inference},
-  year      = {2009},
-  isbn      = {052189560X},
-  publisher = {Cambridge University Press},
-  address   = {USA},
-  edition   = {2nd}
+@article{sachsdataset2005,
+  author   = {Karen Sachs  and Omar Perez  and Dana Pe'er  and Douglas A. Lauffenburger  and Garry P. Nolan },
+  title    = {Causal Protein-Signaling Networks Derived from Multiparameter Single-Cell Data},
+  journal  = {Science},
+  volume   = {308},
+  number   = {5721},
+  pages    = {523-529},
+  year     = {2005},
+  doi      = {10.1126/science.1105809},
+  url      = {https://www.science.org/doi/abs/10.1126/science.1105809},
+  eprint   = {https://www.science.org/doi/pdf/10.1126/science.1105809},
+  abstract = {Machine learning was applied for the automated derivation of causal influences in cellular signaling networks. This derivation relied on the simultaneous measurement of multiple phosphorylated protein and phospholipid components in thousands of individual primary human immune system cells. Perturbing these cells with molecular interventions drove the ordering of connections between pathway components, wherein Bayesian network computational methods automatically elucidated most of the traditionally reported signaling relationships and predicted novel interpathway network causalities, which we verified experimentally. Reconstruction of network models from physiologically relevant primary single cells might be applied to understanding native-state tissue signaling biology, complex drug actions, and dysfunctional signaling in diseased cells.}
 }
 
-@book{Spirtes1993,
-  author    = {Spirtes, Peter and Glymour, Clark and Scheines, Richard},
-  year      = {1993},
-  month     = {01},
-  pages     = {},
-  title     = {Causation, Prediction, and Search},
-  volume    = {81},
-  isbn      = {978-1-4612-7650-0},
-  doi       = {10.1007/978-1-4612-2748-9},
-  publisher = {The MIT Press}
-}
-
-@article{xie2020generalized,
-  title     = {Generalized independent noise condition for estimating latent variable causal graphs},
-  author    = {Xie, Feng and Cai, Ruichu and Huang, Biwei and Glymour, Clark and Hao, Zhifeng and Zhang, Kun},
-  journal   = {Advances in Neural Information Processing Systems},
-  volume    = {33},
-  pages     = {14891--14902},
-  year      = {2020}
-}
-
-@article{dai2022independence,
-  title     = {Independence Testing-Based Approach to Causal Discovery under Measurement Error and Linear Non-Gaussian Models},
-  author    = {Dai, Haoyue and Spirtes, Peter and Zhang, Kun},
-  journal   = {arXiv preprint arXiv:2210.11021},
-  year      = {2022}
-}

--- a/doc/use.rst
+++ b/doc/use.rst
@@ -1,11 +1,11 @@
 :orphan:
 
-Using dodiscover
-=====================
+Examples and Tutorials using DoDiscover
+=======================================
 
-To be able to effectively use dodiscover, look at some of the basic examples here
-to learn everything you need!
-
+To be able to effectively use dodiscover, you can look at some of the basic examples here
+to learn everything you need from concepts to explicit code examples.
 
 .. include:: auto_examples/index.rst
    :start-after: :orphan:
+

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -1,0 +1,24 @@
+.. Places parent toc into the sidebar
+
+:parenttoc: True
+
+.. title:: User guide: contents
+
+.. _user_guide:
+
+==========
+User Guide
+==========
+
+.. toctree::
+   :numbered:
+   :maxdepth: 3
+
+   constraint_causal_discovery.rst
+   conditional_independence.rst
+
+.. scores_causal_discovery.rst
+.. visualizations.rst
+.. datasets.rst
+.. computing.rst
+.. common_pitfalls.rst

--- a/dodiscover/ci/base.py
+++ b/dodiscover/ci/base.py
@@ -258,10 +258,12 @@ class ClassifierCIMixin:
         k: int = 1,
     ) -> Tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike]:
         """Generate dataset for CI testing as binary classification problem.
+
         Based on input data ``(X, Y, Z)``, partitions the dataset into halves, where
         one-half represents the joint distribution of ``P(X, Y, Z)`` and the other
         represents the conditionally independent distribution of ``P(X | Z)P(Y)``.
         This is done by a nearest-neighbor bootstrap approach.
+
         Parameters
         ----------
         x_arr : ArrayLike of shape (n_samples, n_dims_x)
@@ -274,6 +276,7 @@ class ClassifierCIMixin:
             Method to use, by default 'knn'. Can be ('knn', 'kdtree').
         k : int, optional
             Number of nearest neighbors to swap, by default 1.
+
         Returns
         -------
         X_ind, y_ind, X_joint, y_joint : Tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike]
@@ -283,6 +286,7 @@ class ClassifierCIMixin:
             is the data features from the original jointly distributed data.
             ``y_ind`` and ``y_joint`` correspond to the class labels 0 and 1
             respectively.
+
         Notes
         -----
         This algorithm implements a nearest-neighbor bootstrap approach for generating
@@ -322,6 +326,7 @@ class CMIMixin:
         """Compute pvalue by performing a nearest-neighbor shuffle test.
 
         XXX: improve with parallelization with joblib
+
         Parameters
         ----------
         data : pd.DataFrame


### PR DESCRIPTION
Breaking up the PR of #111. This is PR number 2.

Towards #22 

If/when we port to causal-learn, this is easily copyable. This relies on some upstream changes that need to occur in #127. Then the CI will get fixed.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds some user-guide for CI testing and others

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/py-why/dodiscover/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/py-why/dodiscover/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
